### PR TITLE
Throw an error when the given payload is not an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-typescript": "^7.15.0",
     "@types/jest": "^27.0.2",
+    "@types/node": "^17.0.0",
     "jest": "^27.3.1"
   }
 }

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -6,7 +6,6 @@
  */
 
 import {VerificationError} from './errors';
-// @ts-ignore
 import * as crypto from 'crypto';
 
 interface Payload {
@@ -15,6 +14,10 @@ interface Payload {
 }
 
 export function verifyWebhook(data: Payload, signingKey: string, maxAgeSeconds: number = 300): void {
+  if (typeof data !== 'object') {
+    throw new VerificationError('The provided payload is not an object.');
+  }
+
   // Extract the signature
   const { signature } = data;
   delete data.signature;

--- a/tests/verifier.test.ts
+++ b/tests/verifier.test.ts
@@ -3,6 +3,15 @@ import { VerificationError } from '../src/errors';
 import * as crypto from 'crypto';
 
 describe('verifyWebhook', () => {
+  it('throws an error when the payload is not an object', () => {
+    function verify() {
+      // @ts-ignore
+      verifyWebhook('', 'bar');
+    }
+    expect(verify).toThrowError(VerificationError);
+    expect(verify).toThrowError('The provided payload is not an object.');
+  });
+
   it('throws an error when the signature is missing', () => {
     function verify() {
       verifyWebhook({signature: '', created: 1}, 'bar');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,6 +1188,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.5.tgz#e91be5ba4ab88c06095e7b61f9ad1767a1093faf"
   integrity sha512-NyUV2DGcqYIx9op++MG2+Z4Nhw1tPhi0Wfs81TgncuX1aJC4zf2fgCJlJhl4BW9bCSS04e34VkqmOS96w0XQdg==
 
+"@types/node@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
+  integrity sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==
+
 "@types/prettier@^2.1.5":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"


### PR DESCRIPTION
I also added node types as a dependency so we don't have to `ts-ignore` imports from node.